### PR TITLE
Make game responsive on mobile

### DIFF
--- a/apps/clausy-the-cloud/src/App.tsx
+++ b/apps/clausy-the-cloud/src/App.tsx
@@ -349,7 +349,7 @@ export default function App() {
         style={{
           position: 'absolute',
           left: 10,
-          bottom: 30,
+          bottom: 'calc(30px + env(safe-area-inset-bottom, 0px))',
           width: 60,
           height: 60,
           borderRadius: '50%',
@@ -370,7 +370,7 @@ export default function App() {
         style={{
           position: 'absolute',
           right: 10,
-          bottom: 30,
+          bottom: 'calc(30px + env(safe-area-inset-bottom, 0px))',
           width: 60,
           height: 60,
           borderRadius: '50%',

--- a/apps/clausy-the-cloud/src/style.css
+++ b/apps/clausy-the-cloud/src/style.css
@@ -13,10 +13,10 @@ body {
 #game-container {
   position: relative;
   width: 100vw;
-  height: 100vh;
-  max-width: 600px;
-  max-height: 800px;
+  height: 100dvh;
   margin: 0 auto;
+  box-sizing: border-box;
+  padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 20px);
 }
 
 canvas {


### PR DESCRIPTION
## Summary
- scale the canvas to the viewport by using `100dvh` and removing fixed max sizes
- add safe-area padding so mobile Safari chrome doesn't obscure buttons
- move the buttons up with `env(safe-area-inset-bottom)`

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_684e17c96f5883278dacbac584b1495b