### PR TITLE
Fix button text highlight on hold

### DIFF
--- a/apps/clausy-the-cloud/src/style.css
+++ b/apps/clausy-the-cloud/src/style.css
@@ -25,3 +25,9 @@ canvas {
   height: 100%;
   background: #87ceeb;
 }
+
+/* Prevent selection highlight on on-screen controls */
+button {
+  -webkit-user-select: none;
+  user-select: none;
+}


### PR DESCRIPTION
## Summary
- prevent text selection on overlay controls

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_684e197d38c083278f1fcfdd39e5571d