### PR TITLE
Support multi-game builds

### DIFF
--- a/.github/workflows/deploy-games.yml
+++ b/.github/workflows/deploy-games.yml
@@ -1,11 +1,11 @@
-name: Deploy Clausy the Cloud to GitHub Pages
+name: Deploy Games to GitHub Pages
 
 on:
   push:
     branches:
       - main
     paths:
-      - 'apps/clausy-the-cloud/**'
+      - 'apps/**'
 
 permissions:
   contents: read
@@ -36,13 +36,16 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build Clausy the Cloud
-        run: pnpm --filter clausy-the-cloud run build
+      - name: Build all games
+        run: pnpm run build
 
       - name: Prepare deployment folder
         run: |
-          mkdir -p site/clausy-the-cloud
-          cp -r apps/clausy-the-cloud/dist/* site/clausy-the-cloud/
+          for dir in apps/*; do
+            app=$(basename "$dir")
+            mkdir -p "site/$app"
+            cp -r "$dir"/dist/* "site/$app/"
+          done
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,3 +6,4 @@ This file contains project-specific guidelines for agents (e.g., Codex CLI).
 - **Always** prefer `pnpm` versions of commands. For example, use `pnpm exec` instead of `npx` or `npm exec`, and `pnpm run` instead of `npm run`.
 - **Always update** this and any other `AGENTS.md` files when there is a relevant change to dependencies, scripts, or project configuration.
 - **Linting**: use `pnpm lint` to check code quality and catch errors early, and `pnpm lint:fix` to automatically fix lint issues. Configuration now lives in a flat config file: `eslint.config.js`, including ignore patterns via the `ignores` property (see https://eslint.org/docs/latest/use/configure/migration-guide#ignoring-files). The `.eslintignore` file is no longer supported.
+- **Building apps**: use `pnpm build` to compile all games in the `apps` folder. Each app exposes its own `build` script and the root script runs them all.

--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ To automatically fix lint issues, run:
 pnpm lint:fix
 ```
 
-## Building Clausy the Cloud for Production Hosting
+## Building Games for Production Hosting
 
-To build the Clausy the Cloud app for deployment:
+To build all games for deployment:
 
 ```bash
-pnpm --filter clausy-the-cloud build
+pnpm build
 ```
 
-The production-ready files will be generated in `apps/clausy-the-cloud/dist/`.
+Each game will output production files in its `apps/<game>/dist/` folder.
 
-You can then deploy the contents of the `dist` folder to any static hosting provider (e.g., Vercel, Netlify, GitHub Pages, Firebase Hosting, etc.).
+You can deploy the contents of the `dist` folders to any static hosting provider (e.g., Vercel, Netlify, GitHub Pages, Firebase Hosting, etc.).

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
-    "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix"
+    "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
+    "build": "pnpm -r run build"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",


### PR DESCRIPTION
## Summary
- add `pnpm build` script for building all games
- teach agents how to build all games
- document building multiple games
- update deployment workflow to handle every game

## Testing
- `pnpm lint`
- `pnpm format:check`


------
https://chatgpt.com/codex/tasks/task_e_6857f8f4cf3c8327bc00f5576269ef86