### PR TITLE
Improve periphery configuration and clean up unused code

### DIFF
--- a/.periphery.yml
+++ b/.periphery.yml
@@ -1,0 +1,17 @@
+project: VanessaGames/VanessaGames.xcworkspace
+schemes:
+  - ClausyTheCloud
+  - SharedGameEngine
+  - SharedAssets
+relative_results: true
+report_exclude:
+  - '**/Derived/*.swift'
+
+# Retain public APIs for framework targets
+retain_public: true
+# Additional retention rules for dependency injection
+# retain_objc_accessible: false
+# retain_codable_properties: false
+
+# Comment-based exclusions can be added with:
+# // periphery:ignore

--- a/VanessaGames/Games/ClausyTheCloud/Sources/ClausyTheCloudApp.swift
+++ b/VanessaGames/Games/ClausyTheCloud/Sources/ClausyTheCloudApp.swift
@@ -1,4 +1,3 @@
-import SharedGameEngine
 import SwiftUI
 
 @main

--- a/VanessaGames/Games/ClausyTheCloud/Sources/ContentView.swift
+++ b/VanessaGames/Games/ClausyTheCloud/Sources/ContentView.swift
@@ -1,5 +1,4 @@
 import Dependencies
-import SharedAssets
 import SharedGameEngine
 import SwiftUI
 

--- a/VanessaGames/Games/ClausyTheCloud/Tests/SnapshotTests/ContentViewSnapshotTests.swift
+++ b/VanessaGames/Games/ClausyTheCloud/Tests/SnapshotTests/ContentViewSnapshotTests.swift
@@ -1,6 +1,5 @@
 @testable import ClausyTheCloud
 import Dependencies
-import OSLog
 @testable import SharedGameEngine
 import SnapshotTesting
 import SwiftUI
@@ -9,7 +8,6 @@ import Testing
 @MainActor
 @Suite(.snapshots(record: .missing), .enabled(if: ProcessInfo.processInfo.environment["CI"] != "TRUE"))
 struct ContentViewSnapshotTests {
-    let logger = Logger(subsystem: "com.adamalix.vanessagames.clausythecloud", category: "snapshot-tests")
 
     let ciPath: StaticString =
     """

--- a/scripts/periphery.sh
+++ b/scripts/periphery.sh
@@ -1,9 +1,4 @@
 #!/bin/bash
 
-mise exec -- periphery scan \
-    --project VanessaGames/VanessaGames.xcworkspace \
-    --schemes ClausyTheCloud \
-    --schemes SharedGameEngine \
-    --schemes SharedAssets \
-    --relative-results \
-    --report-exclude "**/Derived/*.swift"
+# Use configuration file for cleaner setup
+mise exec -- periphery scan --config .periphery.yml


### PR DESCRIPTION
## Summary
- Remove unused imports and logger property identified by periphery scan
- Add `.periphery.yml` configuration with `--retain-public` flag for better framework API handling
- Simplify periphery script to use configuration file

## Changes
- **ClausyTheCloudApp.swift**: Remove unused `SharedGameEngine` import
- **ContentView.swift**: Remove unused `SharedAssets` import  
- **ContentViewSnapshotTests.swift**: Remove unused `logger` property and `OSLog` import
- **periphery.sh**: Simplify to use configuration file
- **.periphery.yml**: Add configuration with `--retain-public` to handle framework APIs properly

## Test plan
- [x] Periphery scan runs without false positives for framework APIs
- [x] All pre-commit hooks pass
- [x] Code builds and tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)