### PR TITLE
Increase Clausy's movement speed

### DIFF
--- a/VanessaGames/Games/ClausyTheCloud/Tests/ClausyTheCloudTests.swift
+++ b/VanessaGames/Games/ClausyTheCloud/Tests/ClausyTheCloudTests.swift
@@ -25,7 +25,7 @@ struct ClausyTheCloudTests {
         #expect(gameEngine.cloud.yPos == 100)
         #expect(gameEngine.cloud.width == 100)
         #expect(gameEngine.cloud.height == 60)
-        #expect(gameEngine.cloud.speed == 5)
+        #expect(gameEngine.cloud.speed == 8)
 
         // Test initial game state
         #expect(gameEngine.plants.count == 6)
@@ -49,7 +49,7 @@ struct ClausyTheCloudTests {
 
         // Test moving left
         gameEngine.moveCloudLeft()
-        #expect(gameEngine.cloud.xPos == initialX - 5) // speed = 5
+        #expect(gameEngine.cloud.xPos == initialX - 8) // speed = 8
 
         // Test moving right
         gameEngine.moveCloudRight()
@@ -224,7 +224,7 @@ struct ClausyTheCloudTests {
         let defaultCloud = Cloud(xPos: 100, yPos: 50)
         #expect(defaultCloud.width == 100)
         #expect(defaultCloud.height == 60)
-        #expect(defaultCloud.speed == 5)
+        #expect(defaultCloud.speed == 8)
     }
 
     @Test func plantGrowthLogic() {

--- a/VanessaGames/Shared/GameEngine/Sources/GameEngine.swift
+++ b/VanessaGames/Shared/GameEngine/Sources/GameEngine.swift
@@ -56,7 +56,7 @@ public struct Cloud {
     public let height: CGFloat
     public let speed: CGFloat
 
-    public init(xPos: CGFloat, yPos: CGFloat, width: CGFloat = 100, height: CGFloat = 60, speed: CGFloat = 5) {
+    public init(xPos: CGFloat, yPos: CGFloat, width: CGFloat = 100, height: CGFloat = 60, speed: CGFloat = 8) {
         self.xPos = xPos
         self.yPos = yPos
         self.width = width


### PR DESCRIPTION
## Summary
- Increase default cloud speed for faster Clausy movement
- Align unit tests with new default speed

## Testing
- `pnpm lint`
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `./scripts/swiftlint.sh` *(fails: /root/.local/bin/mise: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c18b443b1c8327b2ef862ba19ce04e